### PR TITLE
Sign only our ARC headers when sealing failed chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
   are excluded from the AMS, as required by RFC 8617.
 
 ### Fixed
+- libopenarc - seals on failed chains only cover the latest ARC header set,
+  as required by RFC 8617 section 5.1.2.
 
 ## 1.0.0 - 2024-10-18
 

--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -510,6 +510,11 @@ arc_canon_init(ARC_MESSAGE *msg, _Bool tmp, _Bool keep)
 
 	for (cur = msg->arc_canonhead; cur != NULL; cur = cur->canon_next)
 	{
+		if (cur->canon_hashbuf != NULL)
+		{
+			/* already initialized, nothing to do */
+			continue;
+		}
 		cur->canon_hashbuf = ARC_MALLOC(ARC_HASHBUFSIZE);
 		if (cur->canon_hashbuf == NULL)
 		{

--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -645,7 +645,7 @@ arc_add_canon(ARC_MESSAGE *msg, int type, arc_canon_t canon, int hashtype,
 		     cur != NULL;
 		     cur = cur->canon_next)
 		{
-			if (cur->canon_type == ARC_CANONTYPE_HEADER ||
+			if (cur->canon_type != ARC_CANONTYPE_HEADER ||
 			    cur->canon_hashtype != hashtype)
 				continue;
 

--- a/test/test_milter.py
+++ b/test/test_milter.py
@@ -418,6 +418,22 @@ def test_milter_ar_override_multi(run_miltertest):
     assert res['headers'][3] == ['ARC-Authentication-Results', 'i=2; example.com; arc=pass']
 
 
+def test_milter_seal_failed(run_miltertest):
+    """The seal for failed chains only covers the set from the sealer"""
+    res = run_miltertest()
+
+    # override the result to "fail"
+    headers = res['headers']
+    headers[0][1] = 'example.com; arc=fail'
+    res1 = run_miltertest(headers)
+
+    # mess with the seal
+    headers[1][1] = 'foo'
+    res2 = run_miltertest(headers)
+
+    assert res1['headers'] == res2['headers']
+
+
 def test_milter_authresip(run_miltertest):
     """AuthResIP false disables smtp.remote-ip"""
     res = run_miltertest()


### PR DESCRIPTION
[RFC 8617 section 5.1.2](https://datatracker.ietf.org/doc/html/rfc8617#section-5.1.2).  Marking and Sealing "cv=fail" (Invalid) Chains

In the case of a failed Authenticated Received Chain, the header fields included in the signature scope of the AS header field b= value MUST only include the ARC Set header fields created by the MTA that detected the malformed chain, as if this newest ARC Set was the only set present.

_INFORMATIONAL_: This approach is mandated to handle the case of a malformed or otherwise invalid Authenticated Received Chain.  There is no way to generate a deterministic set of AS header fields ([Section 5.1.1](https://datatracker.ietf.org/doc/html/rfc8617#section-5.1.1)) in most cases of invalid chains.

Fixes https://github.com/trusteddomainproject/OpenARC/issues/75.