### PR TITLE
Exclude all ARC headers from AMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 - milter - `AuthResIP` configuration option.
 
 ### Changed
+- libopenarc - `ARC-Message-Signature` and `ARC-Authentication-Results` headers
+  are excluded from the AMS, as required by RFC 8617.
 
 ### Fixed
 

--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -1206,18 +1206,34 @@ arc_canon_runheaders(ARC_MESSAGE *msg)
 			     hdr != NULL;
 			     hdr = hdr->hdr_next)
 			{
-				/*
-				**  MUST NOT sign ARC-Seal; SHOULD NOT sign
-				**  Authentication-Results
-				*/
-
+				/* RFC 8617 4.1.2
+				 * Authentication-Results header fields MUST NOT
+				 * be included in AMS signatures as they are
+				 * likely to be deleted by downstream ADMDs
+				 * (per [RFC8601], Section 5).
+				 *
+				 * ARC-related header fields
+				 * (ARC-Authentication-Results,
+				 * ARC-Message-Signature, and ARC-Seal) MUST NOT
+				 * be included in the list of header fields
+				 * covered by the signature of the AMS header
+				 * field.
+				 */
 				if (strncasecmp(ARC_EXT_AR_HDRNAME,
 				                hdr->hdr_text,
 				                hdr->hdr_namelen) == 0 ||
 				    strncasecmp(ARC_SEAL_HDRNAME,
 				                hdr->hdr_text,
+				                hdr->hdr_namelen) == 0 ||
+				    strncasecmp(ARC_AR_HDRNAME,
+				                hdr->hdr_text,
+						hdr->hdr_namelen) == 0 ||
+				    strncasecmp(ARC_MSGSIG_HDRNAME,
+				                hdr->hdr_text,
 				                hdr->hdr_namelen) == 0)
+				{
 					continue;
+				}
 
 				if (!lib->arcl_signre)
 				{

--- a/test/test_milter.py
+++ b/test/test_milter.py
@@ -119,6 +119,11 @@ def test_milter_resign(run_miltertest):
         if i <= 50:
             assert res['headers'][3] == ['ARC-Authentication-Results', f'i={i}; example.com; arc=pass smtp.remote-ip=127.0.0.1']
             assert 'cv=pass' in res['headers'][1][1]
+
+            # quick and dirty parsing
+            ams = {x[0].strip(): x[1].strip() for x in [y.split('=', 1) for y in ''.join(res['headers'][2][1].splitlines()).split(';')]}
+            ams_h = [x.strip() for x in ams['h'].lower().split(':')]
+            assert not any([x in ams_h for x in ['authentication-results', 'arc-seal', 'arc-message-signature', 'arc-authentication-results']])
         else:
             assert len(res['headers']) == 1
 


### PR DESCRIPTION
[RFC 6817 section 4.1.2](https://datatracker.ietf.org/doc/html/rfc8617#section-4.1.2).  ARC-Message-Signature (AMS)

ARC-related header fields (ARC-Authentication-Results, ARC- Message-Signature, and ARC-Seal) MUST NOT be included in the list of header fields covered by the signature of the AMS header field.