### PR TITLE
Fix simple canonicalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - libopenarc - `ARC-Message-Signature` and `ARC-Authentication-Results` headers
   are excluded from the AMS, as required by RFC 8617.
+- libopenarc - ARC headers are returned with a space before the header value.
 
 ### Fixed
 - libopenarc - seals on failed chains only cover the latest ARC header set,
   as required by RFC 8617 section 5.1.2.
+- libopenarc - signing with simple header canonicalization works.
 
 ## 1.0.0 - 2024-10-18
 

--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -1048,12 +1048,10 @@ arc_canon_runheaders_seal(ARC_MESSAGE *msg)
 
 				tmphdr.hdr_text = arc_dstring_get(msg->arc_hdrbuf);
 				tmphdr.hdr_namelen = cur->canon_sigheader->hdr_namelen;
-				tmphdr.hdr_colon = tmphdr.hdr_text + (cur->canon_sigheader->hdr_colon - cur->canon_sigheader->hdr_text);
 				tmphdr.hdr_textlen = arc_dstring_len(msg->arc_hdrbuf);
 				tmphdr.hdr_flags = 0;
 				tmphdr.hdr_next = NULL;
 
-				arc_lowerhdr(tmphdr.hdr_text);
 				/* XXX -- void? */
 				(void) arc_canon_header(msg, cur, &tmphdr,
 				                        FALSE);
@@ -1357,7 +1355,6 @@ arc_canon_runheaders(ARC_MESSAGE *msg)
 		/* canonicalize */
 		tmphdr.hdr_text = arc_dstring_get(msg->arc_hdrbuf);
 		tmphdr.hdr_namelen = cur->canon_sigheader->hdr_namelen;
-		tmphdr.hdr_colon = tmphdr.hdr_text + (cur->canon_sigheader->hdr_colon - cur->canon_sigheader->hdr_text);
 		tmphdr.hdr_textlen = arc_dstring_len(msg->arc_hdrbuf);
 		tmphdr.hdr_flags = 0;
 		tmphdr.hdr_next = NULL;
@@ -1427,11 +1424,9 @@ arc_canon_signature(ARC_MESSAGE *msg, struct arc_hdrfield *hdr, int type)
 		}
 		tmphdr.hdr_text = arc_dstring_get(msg->arc_hdrbuf);
 		tmphdr.hdr_namelen = hdr->hdr_namelen;
-		tmphdr.hdr_colon = tmphdr.hdr_text + (hdr->hdr_colon - hdr->hdr_text);
 		tmphdr.hdr_textlen = arc_dstring_len(msg->arc_hdrbuf);
 		tmphdr.hdr_flags = 0;
 		tmphdr.hdr_next = NULL;
-		arc_lowerhdr(tmphdr.hdr_text);
 
 		/* canonicalize the signature */
 		status = arc_canon_header(msg, cur, &tmphdr, FALSE);

--- a/libopenarc/arc-types.h
+++ b/libopenarc/arc-types.h
@@ -57,7 +57,6 @@ struct arc_hdrfield
 	uint32_t		hdr_flags;
 	size_t			hdr_namelen;
 	size_t			hdr_textlen;
-	char *			hdr_colon;
 	char *			hdr_text;
 	void *			hdr_data;
 	struct arc_hdrfield *	hdr_next;

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3716,24 +3716,20 @@ mlfi_eom(SMFICTX *ctx)
 		     sealhdr = arc_hdr_next(sealhdr))
 		{
 			size_t len;
-			char *hfvdest;
+			char *hfvalue;
 			char hfname[BUFRSZ + 1];
-			char hfvalue[ARC_MAXHEADER + 1];
 
 			memset(hfname, '\0', sizeof hfname);
 			strlcpy(hfname, (char *) arc_hdr_name(sealhdr, &len),
 			        sizeof hfname);
 			hfname[len] = '\0';
 
-			hfvdest = hfvalue;
-			memset(hfvalue, '\0', sizeof hfvalue);
-			if (cc->cctx_noleadspc)
+			hfvalue = (char *) arc_hdr_value(sealhdr);
+			if (!cc->cctx_noleadspc)
 			{
-				hfvalue[0] = ' ';
-				hfvdest++;
+				/* strip off the leading space */
+				hfvalue++;
 			}
-			strlcat(hfvalue, (char *) arc_hdr_value(sealhdr),
-			        sizeof hfvalue);
 
 			status = arcf_insheader(ctx, 0, hfname, hfvalue);
 			if (status == MI_FAILURE)

--- a/test/files/test_milter_canon_simple.conf
+++ b/test/files/test_milter_canon_simple.conf
@@ -1,0 +1,7 @@
+Domain          example.com
+AuthservID      example.com
+KeyFile         private.key
+TestKeys        public.key
+Selector        elpmaxe
+Mode            s
+Canonicalization simple/simple

--- a/util/arc-dstring.c
+++ b/util/arc-dstring.c
@@ -479,6 +479,36 @@ arc_dstring_printf(struct arc_dstring *dstr, char *fmt, ...)
 }
 
 /*
+**  ARC_DSTRING_STRIP -- remove matching characters from a string
+**
+**  Parameters:
+**      dstr -- string to process
+**      cset -- characters to remove
+**
+**  Return value:
+**      None.
+*/
+void
+arc_dstring_strip(struct arc_dstring *dstr, const char *cset)
+{
+    size_t newlen = 0;
+    for (size_t i = 0; i <= dstr->ds_len; i++)
+    {
+        while (strchr(cset, dstr->ds_buf[i]) && i <= dstr->ds_len)
+        {
+            i++;
+        }
+        if (i <= dstr->ds_len)
+        {
+            dstr->ds_buf[newlen] = dstr->ds_buf[i];
+            newlen++;
+        }
+    }
+    dstr->ds_buf[newlen] = '\0';
+    dstr->ds_len = newlen;
+}
+
+/*
 **  ARC_COLLAPSE -- remove spaces from a string
 **
 **  Parameters:
@@ -509,38 +539,6 @@ arc_collapse(char *str)
     }
 
     *r = '\0';
-}
-
-/*
-**  ARC_LOWERHDR -- convert a string (presumably a header) to all lowercase,
-**                  but only up to a colon
-**
-**  Parameters:
-**  	str -- string to modify
-**
-**  Return value:
-**  	None.
-*/
-
-void
-arc_lowerhdr(char *str)
-{
-    char *p;
-
-    assert(str != NULL);
-
-    for (p = str; *p != '\0'; p++)
-    {
-        if (*p == ':')
-        {
-            return;
-        }
-
-        if (isascii(*p) && isupper(*p))
-        {
-            *p = tolower(*p);
-        }
-    }
 }
 
 /*

--- a/util/arc-dstring.h
+++ b/util/arc-dstring.h
@@ -28,6 +28,7 @@ extern bool arc_dstring_cat(struct arc_dstring *, const char *);
 extern bool arc_dstring_cat1(struct arc_dstring *, int);
 extern bool arc_dstring_catn(struct arc_dstring *, const char *, size_t);
 extern bool arc_dstring_copy(struct arc_dstring *, const char *);
+extern void arc_dstring_strip(struct arc_dstring *, const char *);
 extern void arc_dstring_free(struct arc_dstring *);
 extern char *arc_dstring_get(struct arc_dstring *);
 extern int arc_dstring_len(struct arc_dstring *);
@@ -37,6 +38,5 @@ extern size_t arc_dstring_printf(struct arc_dstring *dstr, char *fmt, ...);
 extern void arc_clobber_array(char **);
 extern void arc_collapse(char *);
 extern char **arc_copy_array(char **);
-extern void arc_lowerhdr(char *);
 
 #endif /* ARC_DSTRING_H_ */


### PR DESCRIPTION
* The AMS passed to arc-canon has to be in its final form with all whitespace exactly as it will appear in the message.
* Generate ARC headers with a space after the colon since that's nicer looking (and matches what the milter was doing.)
* Lowercasing will be handled by the actual canonicalization if necessary, don't do it preemptively.