### PR TITLE
Implement oldest-pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- `oldest-pass` processing per [RFC 8617 section 5.2](https://datatracker.ietf.org/doc/html/rfc8617#section-5.2).
+- libopenarc - `arc_chain_oldest_pass()`
 - milter - `AuthResIP` configuration option.
 - milter - `RequireSafeKeys` configuration option.
 
@@ -22,6 +24,8 @@ All notable changes to this project will be documented in this file.
   are excluded from the AMS, as required by RFC 8617.
 - libopenarc - ARC headers are returned with a space before the header value.
 - libopenarc - String arguments are marked as `const` where applicable.
+- milter - `Authentication-Results` and `ARC-Authentication-Results` include
+  `header.oldest-pass` when appropriate.
 
 ### Fixed
 - libopenarc - Seals on failed chains only cover the latest ARC header set,
@@ -32,6 +36,8 @@ All notable changes to this project will be documented in this file.
 - libopenarc - The installed pkg-config file is more correct.
 - libopenarc - U-labels (domain labels encoded as UTF-8) are allowed in `d=`
   and `s=` tags.
+- libopenarc - `arc_eom()` propagates internal errors like memory allocation
+  failure instead of marking the chain as failed.
 - milter - Use after free.
 - milter - Unlikely division by zero.
 - milter - Small memory leak during config loading.

--- a/libopenarc/arc-canon.h
+++ b/libopenarc/arc-canon.h
@@ -41,7 +41,7 @@ extern void     arc_canon_cleanup(ARC_MESSAGE *);
 extern ARC_STAT arc_canon_closebody(ARC_MESSAGE *);
 extern ARC_STAT arc_canon_getfinal(ARC_CANON *, unsigned char **, size_t *);
 extern ARC_STAT arc_canon_gethashes(
-    ARC_MESSAGE *, void **, size_t *, void **, size_t *);
+    ARC_MESSAGE *, int, void **, size_t *, void **, size_t *);
 extern ARC_STAT arc_canon_getsealhash(ARC_MESSAGE *, int, void **, size_t *);
 extern ARC_STAT arc_canon_header_string(
     struct arc_dstring *, arc_canon_t, const char *, size_t, bool);

--- a/libopenarc/arc-types.h
+++ b/libopenarc/arc-types.h
@@ -121,6 +121,7 @@ struct arc_msghandle
     bool                 arc_infail;
     int                  arc_dnssec_key;
     int                  arc_signalg;
+    int                  arc_oldest_pass;
     unsigned int         arc_mode;
     unsigned int         arc_nsets;
     unsigned int         arc_margin;
@@ -158,9 +159,9 @@ struct arc_msghandle
     struct arc_dstring  *arc_hdrbuf;
     struct arc_canon    *arc_sealcanon;
     struct arc_canon   **arc_sealcanons;
-    struct arc_canon    *arc_valid_hdrcanon;
+    struct arc_canon   **arc_hdrcanons;
+    struct arc_canon   **arc_bodycanons;
     struct arc_canon    *arc_sign_hdrcanon;
-    struct arc_canon    *arc_valid_bodycanon;
     struct arc_canon    *arc_sign_bodycanon;
     struct arc_canon    *arc_canonhead;
     struct arc_canon    *arc_canontail;

--- a/libopenarc/arc.h
+++ b/libopenarc/arc.h
@@ -610,6 +610,12 @@ extern int arc_chain_custody_str(ARC_MESSAGE   *msg,
                                  size_t         buflen);
 
 /*
+**  ARC_CHAIN_OLDEST_PASS -- retrieve the oldest-pass value
+*/
+
+extern int arc_chain_oldest_pass(ARC_MESSAGE *);
+
+/*
 **  ARC_MAIL_PARSE -- extract the local-part and domain-name from a structured
 **                    header field
 **


### PR DESCRIPTION
* Instead of a single set of validation canons we need one for each ARC instance.
* `arc_add_canon()`'s deduplication of header canons was wrong, it didn't account for `hdrlist` and the hash includes the signature header itself so these are always different.
* Body canons can easily be deduplicated and weren't.
* `arc_eom()` made all errors from the verification routines fail the chain, but `ARC_STAT_INTERNAL` indicates an internal problem which should be reported to the caller instead.