### PR TITLE
Remove accidental line-break in useradd command

### DIFF
--- a/contrib/spec/openarc.spec.in
+++ b/contrib/spec/openarc.spec.in
@@ -153,8 +153,7 @@ EOF
 
 %pre
 if ! getent passwd %{name} >/dev/null 2>&1; then
-    %{_sbindir}/useradd -M -d %{_localstatedir}/lib/%{name} -r -s /sbin/nologin
-%{name}
+    %{_sbindir}/useradd -M -d %{_localstatedir}/lib/%{name} -r -s /sbin/nologin %{name}
     if ! getent group %{name} >/dev/null; then
         %{_sbindir}/groupadd %{name}
         %{_sbindir}/usermod -g %{name} %{name}


### PR DESCRIPTION
The name of the user-to-be-added was on a new line, instead of at the end of the useradd command. This caused an error in the rpm-script when it attempted to create the openarc user.