### PR TITLE
add BuildRequires pkgconfig(libidn2)

### DIFF
--- a/contrib/spec/openarc.spec.in
+++ b/contrib/spec/openarc.spec.in
@@ -17,6 +17,7 @@ BuildRequires: python3-devel
 BuildRequires: pkgconfig(jansson)
 BuildRequires: pkgconfig(libbsd)
 BuildRequires: pkgconfig(openssl)
+BuildRequires: pkgconfig(libidn2)
 
 # sendmail-devel renamed for F25+
 %if 0%{?fedora} > 25


### PR DESCRIPTION
because the package needs this to build on CentOS Stream 9 + EPEL systems at least and it seems it's necessary on other related distributions.