### PR TITLE
Add make srpm target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -123,4 +123,7 @@ dist-hook:
 rpm: dist-gzip
 	rpmbuild -ta $(distdir).tar.gz
 
+srpm: dist-gzip
+	rpmbuild -ts $(distdir).tar.gz
+
 .PHONY: push


### PR DESCRIPTION
I found it convenient to build an SRPM and hand that to mock to build.

This adds a 'make srpm' target, similar to 'make rpm'