### PR TITLE
Modernise open arc systemd service file

### DIFF
--- a/contrib/systemd/openarc.service.in
+++ b/contrib/systemd/openarc.service.in
@@ -8,13 +8,13 @@ After=network.target nss-lookup.target syslog.target
 [Service]
 Type=simple
 EnvironmentFile=-@sysconfdir@/sysconfig/openarc
+ExecStartPre=-/usr/bin/install -d -m 0750 -o openarc -g openarc @localstatedir@/run/openarc
 ExecStart=@sbindir@/openarc -f $OPTIONS
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecReload=+/bin/kill -USR1 $MAINPID
 Restart=on-abnormal
 User=openarc
 Group=openarc
 PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/install -d -m 0755 -o openarc -g openarc @localstatedir@/run/openarc
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/openarc.service.in
+++ b/contrib/systemd/openarc.service.in
@@ -15,6 +15,9 @@ Restart=on-abnormal
 User=openarc
 Group=openarc
 PermissionsStartOnly=true
+ProtectSystem=strict
+ProtectHome=true
+
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The following changes are proposed here:

1. Updated the `systemd` service file for the deprecated `PermissionsStartOnly`. We can keep that line in the service file for those OS's that have a version of systemd that predates the deprecation of that function (i.e. from before July 2020).
2. Changed the mode of the `/run/openarc` directory from 0755 to 0750. No need for it to be world-readable.
3. Restrict access to the rest of the filesystem by declaring `ProtectSystem=strict` and `ProtectHome=true`.
