### PR TITLE
Fix typo in configure.ac: sertservers --> setservers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,7 +97,7 @@ AC_SEARCH_LIBS(getaddrinfo, resolv,
 AC_SEARCH_LIBS(res_ninit, resolv,
                AC_DEFINE(HAVE_RES_NINIT, 1,
                          [Define to 1 if you have the res_ninit() function.]))
-AC_SEARCH_LIBS(res_sertservers, resolv bind,
+AC_SEARCH_LIBS(res_setservers, resolv bind,
                AC_DEFINE(HAVE_RES_SETSERVERS, 1,
                          [Define to 1 if you have the res_setservers() function.]))
 AC_SEARCH_LIBS(getopt_long, iberty,


### PR DESCRIPTION
`res_sertservers` should be `res_setservers`.