### PR TITLE
Add AuthResComments config flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- milter - `AuthResComments` configuration option.
 
 ### Changed
 

--- a/openarc/openarc-config.h
+++ b/openarc/openarc-config.h
@@ -13,6 +13,7 @@
 
 /* config definition */
 struct configdef arcf_config[] = {
+    {"AuthResComments",               CONFIG_TYPE_BOOLEAN, false},
     {"AuthResIP",                     CONFIG_TYPE_BOOLEAN, false},
     {"AuthservID",                    CONFIG_TYPE_STRING,  false},
     {"AutoRestart",                   CONFIG_TYPE_BOOLEAN, false},

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -113,6 +113,7 @@ struct arcf_config
     bool            conf_keeptmpfiles;      /* keep temp files */
     bool            conf_finalreceiver;     /* act as final receiver */
     bool            conf_overridecv;        /* allow A-R to override CV */
+    bool            conf_authrescomments;   /* include comments in A-R */
     bool            conf_authresip;         /* include remote IP in A-R */
     unsigned int    conf_refcnt;            /* reference count */
     unsigned int    conf_mode;              /* mode flags */
@@ -1165,6 +1166,7 @@ arcf_config_new(void)
 
     new->conf_maxhdrsz = DEFMAXHDRSZ;
     new->conf_safekeys = true;
+    new->conf_authrescomments = true;
     new->conf_authresip = true;
 
     new->conf_ret_disabled = SMFIS_ACCEPT;
@@ -1512,6 +1514,9 @@ arcf_config_load(struct config      *data,
 
         (void) config_get(data, "PermitAuthenticationOverrides",
                           &conf->conf_overridecv, sizeof conf->conf_overridecv);
+
+        config_get(data, "AuthResComments", &conf->conf_authrescomments,
+                   sizeof conf->conf_authrescomments);
 
         config_get(data, "AuthResIP", &conf->conf_authresip,
                    sizeof conf->conf_authresip);
@@ -3847,8 +3852,11 @@ mlfi_eom(SMFICTX *ctx)
             {
                 if (ar.ares_result[i].result_ptype[j] == ARES_PTYPE_COMMENT)
                 {
-                    arc_dstring_printf(afc->mctx_tmpstr, " %s",
-                                       ar.ares_result[i].result_value[j]);
+                    if (conf->conf_authrescomments)
+                    {
+                        arc_dstring_printf(afc->mctx_tmpstr, " %s",
+                                           ar.ares_result[i].result_value[j]);
+                    }
                 }
                 else
                 {

--- a/openarc/openarc.conf.5.in
+++ b/openarc/openarc.conf.5.in
@@ -53,6 +53,11 @@ integer values default to
 and string and dataset values default to being undefined.
 .Sh PARAMETERS
 .Bl -tag -width Ds
+.It Cm AuthResComments Pq boolean
+Controls whether Authentication-Results headers include any comments parsed from
+the previously existing headers.
+The default is
+.Cm true .
 .It Cm AuthResIP Pq boolean
 Controls whether Authentication-Results headers include the remote IP.
 The default is

--- a/openarc/openarc.conf.sample
+++ b/openarc/openarc.conf.sample
@@ -3,6 +3,7 @@
 # Only brief examples of each configuration option are provided. For
 # detailed documentation, consult the openarc.conf(5) man page.
 
+# AuthResComments               true
 # AuthResIP                     true
 
 AuthservID                      example.com

--- a/test/files/test_milter_authrescomments.conf
+++ b/test/files/test_milter_authrescomments.conf
@@ -1,0 +1,3 @@
+{
+  "AuthResComments": "false"
+}

--- a/test/test_milter.py
+++ b/test/test_milter.py
@@ -324,6 +324,22 @@ def test_milter_ar(run_miltertest, data):
     assert res['headers'][3] == ['ARC-Authentication-Results', f' i=1; example.com; {data[1]}']
 
 
+def test_milter_authrescomments(run_miltertest):
+    """AuthResComments=false strips out even reasonably-placed comments"""
+    res = run_miltertest(
+        [
+            [
+                'Authentication-Results',
+                'example.com; (a)spf (Sender Policy Framework) = pass (good) smtp (mail transfer) . (protocol) mailfrom = foo@example.com',
+            ]
+        ]
+    )
+    assert res['headers'][3] == [
+        'ARC-Authentication-Results',
+        ' i=1; example.com; spf=pass smtp.mailfrom=foo@example.com;\n\tarc=none smtp.remote-ip=127.0.0.1',
+    ]
+
+
 def test_milter_ar_override(run_miltertest):
     """Override the chain validation state with Authentication-Results"""
     res = run_miltertest()


### PR DESCRIPTION
Neither keeping nor stripping comments is inherently better, it's reasonable to want either one so it should be configurable.

Closes #33, I guess.